### PR TITLE
Fixed problem with assigning text value to Input component

### DIFF
--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -11,8 +11,8 @@ module EZGUI.Component {
         public focused: boolean;
 
         get text(): string {
-            if (this.domInput && this.domInput.value) return this.domInput.value;
-            if (this.textObj) return this.textObj.text;
+            if (this.domInput) return this.domInput.value;
+            return ""
         }
         set text(val: string) {
             if (this.textObj) {

--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -17,11 +17,15 @@ module EZGUI.Component {
         set text(val: string) {
             if (this.textObj) {
                 var cpos = this.getCaretPosition();
-                if (Compatibility.PIXIVersion == 3) {
-                    this.textObj.text = val.substr(0, cpos) + '|' + val.substr(cpos);
+                var text = val;
+                if(!EZGUI.Device.isMobile){ //Don't show cursor on mobile
+                    text = val.substr(0, cpos) + '|' + val.substr(cpos);
+                }
+                if (EZGUI.Compatibility.PIXIVersion == 3) {
+                    this.textObj.text = text;
                 }
                 else {
-                    this.textObj.setText(val.substr(0, cpos) + '|' + val.substr(cpos));
+                    this.textObj.setText(text);
                 }
                 this.domInput.value = val;
                 this.setCaretPosition(cpos);
@@ -119,7 +123,7 @@ module EZGUI.Component {
         protected setupEvents() {
             super.setupEvents();
 
-            if (!EZGUI.Device.isMobile && document && document.createElement) {
+            if (document && document.createElement) {
                 this.domInput = document.createElement("input");
                 this.domInput.id = this.guiID + "_input";
                 this.domInput.style.position = 'absolute';

--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -16,12 +16,15 @@ module EZGUI.Component {
         }
         set text(val: string) {
             if (this.textObj) {
+                var cpos = this.getCaretPosition();
                 if (Compatibility.PIXIVersion == 3) {
-                    this.textObj.text = val;
+                    this.textObj.text = val.substr(0, cpos) + '|' + val.substr(cpos);
                 }
                 else {
-                    this.textObj.setText(val);
+                    this.textObj.setText(val.substr(0, cpos) + '|' + val.substr(cpos));
                 }
+                this.domInput.value = val;
+                this.setCaretPosition(cpos);
 
                 if (this._settings.anchor) {
                     this.textObj.position.x = 0;
@@ -127,31 +130,15 @@ module EZGUI.Component {
                 var _this: any = this;
                 
                 this.domInput.addEventListener('input', function (event) {
-
-                    var cpos = _this.getCaretPosition();
-                    var str: string = _this.domInput.value;                    
-
-                    _this.text = str.substr(0, cpos) + '|' + str.substr(cpos);
-
-                    _this.text = str;
+                    _this.text = _this.domInput.value;
                     _this.emit('ezgui:change', event, _this);
                 });
                 this.domInput.addEventListener('keydown', function (event) {
-
-                    var cpos = _this.getCaretPosition();
-                    var str: string = _this.domInput.value;
-
-                    _this.text = str.substr(0, cpos) + '|' + str.substr(cpos);
-                    
+                    _this.text = _this.domInput.value;
                 });
 
                 this.domInput.addEventListener('keyup', function (event) {
-
-                    var cpos = _this.getCaretPosition();
-                    var str: string = _this.domInput.value;
-
-                    _this.text = str.substr(0, cpos) + '|' + str.substr(cpos);
-
+                    _this.text = _this.domInput.value;
                 });
             }
         }
@@ -170,28 +157,14 @@ module EZGUI.Component {
             }
 
             guiObj.on('focus', function () {
-                if (_this.focused) return;
-                _this.focused = true;
-
                 if (!_this.domInput) return;
-                _this.domInput.value = _this.text;
-
-                _this.setCaretPosition(_this.domInput.value.length);
-                var cpos = _this.getCaretPosition();
-                var str: string = _this.domInput.value;
-                _this.text = str.substr(0, cpos) + '|' + str.substr(cpos);
-
-
+                _this.text = _this.domInput.value;
                 _this.domInput.focus();
 
             });
             guiObj.on('blur', function () {
-                if (!_this.focused) return;
-                _this.focused = false;
-
                 if (!_this.domInput) return;
                 _this.text = _this.domInput.value;
-                //_this.text = _this.text.substr(0, _this.text.length - 1);
                 _this.domInput.blur();
             });
 


### PR DESCRIPTION
Previously following line

EZGUI.components.myInput.text = "some text"

Worked incorrectly, the text was set temporarily to the value "some text" but after dom input received focus it the text was overrided by whatever was inside dom input.
