### PR TITLE
Allow tilable backgrounds in both directions

### DIFF
--- a/dist/EZGUI.js
+++ b/dist/EZGUI.js
@@ -2180,8 +2180,12 @@ var EZGUI;
                 if (settings.bgTiling == "x") {
                     bg.tileScale.y = (settings.height - cfg.bgPadding * 2) / cfg.texture.height;
                 }
-                if (settings.bgTiling == "y") {
+                else if (settings.bgTiling === "y") {
                     bg.tileScale.x = (settings.width - cfg.bgPadding * 2) / cfg.texture.width;
+                }
+                else if (settings.bgTiling === "xy") {
+                    bg.tileScale.x = (settings.width - cfg.bgPadding * 2) / cfg.texture.width;
+                    bg.tileScale.y = (settings.height - cfg.bgPadding * 2) / cfg.texture.height;
                 }
             }
             return bg;

--- a/src/GUISprite.ts
+++ b/src/GUISprite.ts
@@ -922,13 +922,19 @@ module EZGUI {
 
 
             if (settings.bgTiling) {
-                if (settings.bgTiling == "x") {
-                    
+                if (settings.bgTiling === "x") {
+
                     bg.tileScale.y = (settings.height - cfg.bgPadding * 2) / cfg.texture.height;
                 }
 
-                if (settings.bgTiling == "y") {
-                    
+                else if (settings.bgTiling === "y") {
+
+                    bg.tileScale.x = (settings.width - cfg.bgPadding * 2) / cfg.texture.width;
+                }
+
+                else if (settings.bgTiling === "xy") {
+
+                    bg.tileScale.y = (settings.height - cfg.bgPadding * 2) / cfg.texture.height;
                     bg.tileScale.x = (settings.width - cfg.bgPadding * 2) / cfg.texture.width;
                 }
 


### PR DESCRIPTION
Allows you to set the tiling direction to both directions.

![52d243067e54308fbcdf177387dd2044](https://cloud.githubusercontent.com/assets/10748168/13968268/2529bbf6-f07c-11e5-9405-69b75726bdea.png)

This way, you can set a single image as your background image, which may come in useful for games.
In your JSON, the `bgTiling` property now accepts `x`, `y` and `xy`. Where `xy` removes the tiling completely. Play around with the `bgPadding` property to achieve the result from the image.
