### PR TITLE
Update Phaser version check

### DIFF
--- a/src/Compatibility.ts
+++ b/src/Compatibility.ts
@@ -7,7 +7,7 @@ module EZGUI.Compatibility {
     export var PIXIVersion =
         (PIXI.VERSION.indexOf('v3.') == 0 || PIXI.VERSION.indexOf('3.') == 0) ? 3 : 2;
     export var isPhaser = (typeof Phaser != 'undefined');
-    export var isPhaser24 = isPhaser && Phaser.VERSION.indexOf('2.4') == 0;
+    export var isPhaser24 = isPhaser && Phaser.VERSION>='2.4';
 
     export var BitmapText = PIXIVersion >= 3 ? (<any>PIXI).extras.BitmapText : PIXI.BitmapText;
 


### PR DESCRIPTION
Old check was to see if "2.4" was the start of the Phaser version. New check compares with >=, so any Phaser version 2.4 or higher (like the current 2.5) will enable isPhaser24.

I don't have elaborate tests of EZGUI feature functionality in Phaser 2.5, but the limited EZGUI features I"m using seem to work fine as long as we pretend it's a "isPhaser24" build. 
